### PR TITLE
SAPI-435 Implement service

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,8 +3,10 @@ package config
 import "github.com/ian-kent/gofigure"
 
 type Config struct {
-	gofigure    interface{} `order:"env,flag"`
-	BindAddress string      `env:"BIND_ADDRESS" flag:"bind-address"`
+	gofigure          interface{} `order:"env,flag"`
+	BindAddress       string      `env:"BIND_ADDRESS" flag:"bind-address"`
+	KafkaBroker       []string    `env:"KAFKA_BROKER_ADDR" flag:"kafka-broker-addr"`
+	SchemaRegistryURL string      `env:"SCHEMA_REGISTRY_URL" flag:"schema-registry-url"`
 }
 
 var config *Config

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -6,3 +6,24 @@ type Logger interface {
 	Error(err error, data ...log.Data)
 	Info(msg string, data ...log.Data)
 }
+
+var logger LoggerImpl
+
+type LoggerImpl struct {
+}
+
+func NewLogger() *LoggerImpl {
+	return &logger
+}
+
+func (l *LoggerImpl) Error(err error, data ...log.Data) {
+	log.Error(err, data...)
+}
+
+func (l *LoggerImpl) Info(msg string, data ...log.Data) {
+	log.Info(msg, data...)
+}
+
+func (l *LoggerImpl) InfoR(req *http.Request, message string, data ...log.Data) {
+	log.InfoR(req, message, data...)
+}

--- a/service/service.go
+++ b/service/service.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"github.com/companieshouse/chs-streaming-api-backend/broker"
+	"github.com/companieshouse/chs-streaming-api-backend/config"
+	backendconsumer "github.com/companieshouse/chs-streaming-api-backend/consumer"
+	"github.com/companieshouse/chs-streaming-api-backend/handler"
+	"github.com/companieshouse/chs-streaming-api-backend/logger"
+	"github.com/companieshouse/chs-streaming-api-backend/transformer"
+	"github.com/companieshouse/chs-streaming-api-backend/transformer/jsonproducer"
+	"github.com/companieshouse/chs.go/avro"
+	"github.com/companieshouse/chs.go/kafka/consumer"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/pat"
+	"net/http"
+)
+
+type BackendService struct {
+	broker       *broker.Broker
+	consumer     *backendconsumer.KafkaMessageConsumer
+	kafkaBrokers []string
+	schema       *avro.Schema
+	router       *pat.Router
+}
+
+type Router interface {
+	Get(path string, handler http.HandlerFunc) *mux.Route
+}
+
+type BackendConfiguration struct {
+	Configuration *config.Config
+	Schema        *avro.Schema
+	Router        *pat.Router
+}
+
+func NewBackendService(cfg *BackendConfiguration) *BackendService {
+	return &BackendService{
+		broker:       broker.NewBroker(),
+		schema:       cfg.Schema,
+		kafkaBrokers: cfg.Configuration.KafkaBroker,
+		router:       cfg.Router,
+	}
+}
+
+func (s *BackendService) WithTopic(topic string) *BackendService {
+	s.consumer = backendconsumer.NewConsumer(
+		consumer.NewPartitionConsumer(&consumer.Config{
+			BrokerAddr: s.kafkaBrokers,
+			Topics:     []string{topic},
+		}),
+		transformer.NewResourceChangedDataTransformer(
+			transformer.NewDeserialiser(s.schema, jsonproducer.Instance()),
+			transformer.NewSerialiser(jsonproducer.Instance(), jsonproducer.Instance())),
+		s.broker,
+		logger.NewLogger())
+	return s
+}
+
+func (s *BackendService) WithPath(path string) *BackendService {
+	s.router.Path(path).Methods("GET").HandlerFunc(handler.NewRequestHandler(s.broker, logger.NewLogger()).HandleRequest)
+	return s
+}
+
+func (s *BackendService) Start() {
+	go s.consumer.Run()
+	go s.broker.Run()
+}

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,80 @@
+package service
+
+import (
+	"github.com/companieshouse/chs-streaming-api-backend/config"
+	"github.com/companieshouse/chs-streaming-api-backend/consumer"
+	backendhandler "github.com/companieshouse/chs-streaming-api-backend/handler"
+	"github.com/companieshouse/chs.go/avro"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/pat"
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+func TestCreateNewService(t *testing.T) {
+	Convey("When a new service instance is constructed", t, func() {
+		configuration := &BackendConfiguration{
+			Configuration: &config.Config{
+				KafkaBroker: []string{"0.0.0.0"},
+			},
+			Schema: &avro.Schema{},
+			Router: pat.New(),
+		}
+		actual := NewBackendService(configuration)
+		Convey("Then a new service instance reference should be returned", func() {
+			So(actual, ShouldNotBeNil)
+			So(actual.broker, ShouldNotBeNil)
+			So(actual.schema, ShouldEqual, configuration.Schema)
+			So(actual.kafkaBrokers, ShouldResemble, configuration.Configuration.KafkaBroker)
+			So(actual.router, ShouldEqual, configuration.Router)
+		})
+	})
+}
+
+func TestBindKafkaTopic(t *testing.T) {
+	Convey("Given a new service instance has been constructed", t, func() {
+		configuration := &BackendConfiguration{
+			Configuration: &config.Config{
+				KafkaBroker: []string{"0.0.0.0"},
+			},
+			Schema: &avro.Schema{},
+			Router: pat.New(),
+		}
+		service := NewBackendService(configuration)
+		Convey("When a kafka topic is bound to it", func() {
+			actual := service.WithTopic("topic")
+			Convey("Then a new partition consumer should be allocated to the service", func() {
+				So(actual, ShouldEqual, service)
+				So(service.consumer, ShouldHaveSameTypeAs, &consumer.KafkaMessageConsumer{})
+			})
+		})
+	})
+}
+
+func TestAttachRequestHandler(t *testing.T) {
+	Convey("Given a new service instance has been constructed", t, func() {
+		configuration := &BackendConfiguration{
+			Configuration: &config.Config{
+				KafkaBroker: []string{"0.0.0.0"},
+			},
+			Schema: &avro.Schema{},
+			Router: pat.New(),
+		}
+		service := NewBackendService(configuration)
+		Convey("When a request handler is attached to it", func() {
+			actual := service.WithPath("/path")
+			Convey("Then a new request handler should be allocated to the service", func() {
+				So(actual, ShouldEqual, service)
+				_ = configuration.Router.Walk(func(r *mux.Route, o *mux.Router, u []*mux.Route) error {
+					path, _ := r.GetPathTemplate()
+					methods, _ := r.GetMethods()
+					handler := r.GetHandler()
+					So(path, ShouldEqual, "/path")
+					So(methods, ShouldResemble, []string{"GET"})
+					So(handler, ShouldEqual, (&backendhandler.RequestHandler{}).HandleRequest)
+					return nil
+				})
+			})
+		})
+	})
+}


### PR DESCRIPTION
* Encapsulate consumer, request handler and broker in a single object.
* Use builder pattern to harness service.
* One service instance per stream.