### PR TITLE
Consume from specified partition and offset

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -52,6 +52,8 @@ func (s *BackendService) WithTopic(topic string) *BackendService {
 			transformer.NewDeserialiser(s.schema, jsonproducer.Instance()),
 			transformer.NewSerialiser(jsonproducer.Instance(), jsonproducer.Instance())),
 		s.broker,
+		0,
+		-1,
 		logger.NewLogger())
 	return s
 }


### PR DESCRIPTION
* Required by associated Kafka consumer so that messages can be consumed from configured topic.