### PR TITLE
Set port for chs-streaming-api-backend to 6000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-builde
 
 FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-runtime
 
-CMD ["-bind-address=:9999"]
+CMD ["-bind-address=:6000"]
 
-EXPOSE 9999
+EXPOSE 6000


### PR DESCRIPTION
* Align port for chs-streaming-api-backend with docker-chs-development.